### PR TITLE
顯示created_at 資料，並可依據created_at 作排序

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -41,7 +41,16 @@
     "react/require-default-props": "off",
     "flowtype/define-flow-type": 1,
     "flowtype/use-flow-type": 1,
-    "prettier/prettier": "error"
+    "prettier/prettier": "error",
+    "no-console": [
+      "error",
+      {
+        "allow": [
+          "warn",
+          "error"
+        ]
+      }
+    ]
   },
   "settings": {
     "import/resolver": {

--- a/.eslintrc
+++ b/.eslintrc
@@ -47,7 +47,8 @@
       {
         "allow": [
           "warn",
-          "error"
+          "error",
+          "info"
         ]
       }
     ]

--- a/server.js
+++ b/server.js
@@ -10,4 +10,4 @@ app.use(express.static(appBuild));
 
 app.get('*', (req, res) => res.sendFile(path.join(appBuild, '/index.html')));
 
-app.listen(PORT, () => console.log(`the app listening on ${PORT}!`));
+app.listen(PORT, () => console.info(`the app listening on ${PORT}!`));

--- a/src/Root/errorLink.js
+++ b/src/Root/errorLink.js
@@ -10,7 +10,7 @@ const errorLink = onError(({ graphQLErrors, networkError, operation, response })
     graphQLErrors.map(({ message, locations, path }) =>
       console.error(`[GraphQL error]: Message: ${message}, Location: ${locations}, Path: ${path}`)
     );
-    // ignore graphql errors w(though type is invalid, but render anyway )
+    // ignore graphql errors (though type is invalid, but render anyway )
     response.errors = null;
   }
 

--- a/src/Root/errorLink.js
+++ b/src/Root/errorLink.js
@@ -5,11 +5,14 @@ import { getLoginStatusGQL } from '../graphql/loginStatus';
 
 import { LOGIN_STATUS } from '../shared/constants';
 
-const errorLink = onError(({ graphQLErrors, networkError, operation }) => {
-  if (graphQLErrors)
+const errorLink = onError(({ graphQLErrors, networkError, operation, response }) => {
+  if (graphQLErrors) {
     graphQLErrors.map(({ message, locations, path }) =>
       console.error(`[GraphQL error]: Message: ${message}, Location: ${locations}, Path: ${path}`)
     );
+    // ignore graphql errors w(though type is invalid, but render anyway )
+    response.errors = null;
+  }
 
   if (networkError) {
     const { cache } = operation.getContext();

--- a/src/components/Admin/Interview.js
+++ b/src/components/Admin/Interview.js
@@ -12,6 +12,7 @@ import AdminLayout from './AdminLayout';
 import FunctionalTable from '../FunctionalTable';
 import withPagination from '../../shared/hoc/withPagination';
 import withSearchOptionFromRoute from '../../shared/hoc/withSearchOptionFromRoute';
+import withSortOptionFromRoute from '../../shared/hoc/withSortOptionFromRoute';
 import { ORDER_BY } from '../../shared/constants';
 
 const COLUMNS = [
@@ -154,6 +155,7 @@ const withGraphqlMutation: HOC<*, Props> = compose(
 );
 
 const hoc = compose(
+  withSortOptionFromRoute,
   withSearchOptionFromRoute,
   withPagination,
   withGraphqlData,

--- a/src/components/Admin/Interview.js
+++ b/src/components/Admin/Interview.js
@@ -14,6 +14,7 @@ import FunctionalTable from '../FunctionalTable';
 import withPagination from '../../shared/hoc/withPagination';
 import withSearchOptionFromRoute from '../../shared/hoc/withSearchOptionFromRoute';
 import withSortOptionFromRoute from '../../shared/hoc/withSortOptionFromRoute';
+import withHandleTableChange from '../../shared/hoc/withHandleTableChange';
 import { ORDER_BY } from '../../shared/constants';
 
 const COLUMNS = [
@@ -165,7 +166,8 @@ const hoc = compose(
   withSearchOptionFromRoute,
   withPagination,
   withGraphqlData,
-  withGraphqlMutation
+  withGraphqlMutation,
+  withHandleTableChange
 );
 
 export default hoc(Interview);

--- a/src/components/Admin/Interview.js
+++ b/src/components/Admin/Interview.js
@@ -15,7 +15,7 @@ import withPagination from '../../shared/hoc/withPagination';
 import withSearchOptionFromRoute from '../../shared/hoc/withSearchOptionFromRoute';
 import withSortOptionFromRoute from '../../shared/hoc/withSortOptionFromRoute';
 import withHandleTableChange from '../../shared/hoc/withHandleTableChange';
-import { ORDER_BY } from '../../shared/constants';
+import { type OrderBy } from '../../shared/constants';
 
 const COLUMNS = [
   {
@@ -28,7 +28,8 @@ const COLUMNS = [
     title: '創建時間',
     dataIndex: 'created_at',
     key: 'created_at',
-    render: createdAt => moment(createdAt).format('LLLL')
+    render: createdAt => moment(createdAt).format('LLLL'),
+    sorter: true
   },
   {
     title: '公司',
@@ -61,10 +62,13 @@ const COLUMNS = [
 type Props = {
   page: number,
   pageSize: number,
-
   searchObj: {
     columnKey: string,
     value: string
+  },
+  sortObj: {
+    sortField: string,
+    orderBy: OrderBy
   },
   setSearchObj: ({
     columnKey: string,
@@ -98,6 +102,7 @@ const withGraphqlData: HOC<*, Props> = compose(
     options: props => {
       const {
         searchObj: { columnKey, value },
+        sortObj: { sortField, orderBy },
         page,
         pageSize
       } = props;
@@ -112,8 +117,8 @@ const withGraphqlData: HOC<*, Props> = compose(
             start: (page - 1) * pageSize,
             limit: pageSize,
             sort: {
-              sort_field: 'CREATED_AT',
-              order_by: ORDER_BY.ASCENDING
+              sort_field: sortField,
+              order_by: orderBy
             }
           }
         }

--- a/src/components/Admin/Interview.js
+++ b/src/components/Admin/Interview.js
@@ -20,6 +20,7 @@ const COLUMNS = [
     key: 'id',
     searchable: true
   },
+  { title: '創建時間', dataIndex: 'created_at', key: 'created_at' },
   {
     title: '公司',
     dataIndex: 'company',

--- a/src/components/Admin/Interview.js
+++ b/src/components/Admin/Interview.js
@@ -4,6 +4,7 @@ import { graphql } from 'react-apollo';
 import { Tag } from 'antd';
 
 import { withProps, compose, type HOC } from 'recompose';
+import moment from 'moment';
 
 import { getInterviewExpQL, updateInterviewExpQL } from '../../graphql/InterviewExperience/';
 import type { ExperienceType } from '../../shared/types/experienceType';
@@ -22,7 +23,12 @@ const COLUMNS = [
     key: 'id',
     searchable: true
   },
-  { title: '創建時間', dataIndex: 'created_at', key: 'created_at' },
+  {
+    title: '創建時間',
+    dataIndex: 'created_at',
+    key: 'created_at',
+    render: createdAt => moment(createdAt).format('LLLL')
+  },
   {
     title: '公司',
     dataIndex: 'company',

--- a/src/components/Admin/Interview.js
+++ b/src/components/Admin/Interview.js
@@ -12,6 +12,7 @@ import AdminLayout from './AdminLayout';
 import FunctionalTable from '../FunctionalTable';
 import withPagination from '../../shared/hoc/withPagination';
 import withSearchOptionFromRoute from '../../shared/hoc/withSearchOptionFromRoute';
+import { ORDER_BY } from '../../shared/constants';
 
 const COLUMNS = [
   {
@@ -101,7 +102,11 @@ const withGraphqlData: HOC<*, Props> = compose(
               by: columnKey.toUpperCase()
             },
             start: (page - 1) * pageSize,
-            limit: pageSize
+            limit: pageSize,
+            sort: {
+              sort_field: 'CREATED_AT',
+              order_by: ORDER_BY.ASCENDING
+            }
           }
         }
       };

--- a/src/components/Admin/TimeAndSalary.js
+++ b/src/components/Admin/TimeAndSalary.js
@@ -4,6 +4,7 @@ import { graphql } from 'react-apollo';
 import { Tag } from 'antd';
 
 import { withProps, compose, type HOC } from 'recompose';
+import moment from 'moment';
 
 import { getTimeSalaryQL, updateTimeSalaryQL } from '../../graphql/TimeAndSalary/';
 import type { ExperienceType } from '../../shared/types/experienceType';
@@ -22,7 +23,12 @@ const COLUMNS = [
     key: 'id',
     searchable: true
   },
-  { title: '創建時間', dataIndex: 'created_at', key: 'created_at' },
+  {
+    title: '創建時間',
+    dataIndex: 'created_at',
+    key: 'created_at',
+    render: createdAt => moment(createdAt).format('LLLL')
+  },
   {
     title: '公司',
     dataIndex: 'company',

--- a/src/components/Admin/TimeAndSalary.js
+++ b/src/components/Admin/TimeAndSalary.js
@@ -12,6 +12,7 @@ import AdminLayout from './AdminLayout';
 import FunctionalTable from '../FunctionalTable';
 import withPagination from '../../shared/hoc/withPagination';
 import withSearchOptionFromRoute from '../../shared/hoc/withSearchOptionFromRoute';
+import { ORDER_BY } from '../../shared/constants';
 
 const COLUMNS = [
   {
@@ -130,7 +131,11 @@ const withGraphqlData: HOC<*, Props> = compose(
               by: columnKey.toUpperCase()
             },
             start: (page - 1) * pageSize,
-            limit: pageSize
+            limit: pageSize,
+            sort: {
+              sort_field: 'CREATED_AT',
+              order_by: ORDER_BY.ASCENDING
+            }
           }
         }
       };

--- a/src/components/Admin/TimeAndSalary.js
+++ b/src/components/Admin/TimeAndSalary.js
@@ -14,6 +14,8 @@ import FunctionalTable from '../FunctionalTable';
 import withPagination from '../../shared/hoc/withPagination';
 import withSearchOptionFromRoute from '../../shared/hoc/withSearchOptionFromRoute';
 import withSortOptionFromRoute from '../../shared/hoc/withSortOptionFromRoute';
+import withHandleTableChange from '../../shared/hoc/withHandleTableChange';
+
 import { ORDER_BY } from '../../shared/constants';
 
 const COLUMNS = [
@@ -196,7 +198,8 @@ const hoc = compose(
   withSearchOptionFromRoute,
   withPagination,
   withGraphqlData,
-  withGraphqlMutation
+  withGraphqlMutation,
+  withHandleTableChange
 );
 
 export default hoc(TimeAndSalary);

--- a/src/components/Admin/TimeAndSalary.js
+++ b/src/components/Admin/TimeAndSalary.js
@@ -20,6 +20,7 @@ const COLUMNS = [
     key: 'id',
     searchable: true
   },
+  { title: '創建時間', dataIndex: 'created_at', key: 'created_at' },
   {
     title: '公司',
     dataIndex: 'company',

--- a/src/components/Admin/TimeAndSalary.js
+++ b/src/components/Admin/TimeAndSalary.js
@@ -53,21 +53,18 @@ const COLUMNS = [
   {
     title: '薪資金額',
     dataIndex: 'salary_amount',
-    key: 'salary_amount',
-    sortable: true
+    key: 'salary_amount'
   },
   {
     title: '估計時薪',
     dataIndex: 'estimated_hourly_wage',
     key: 'estimated_hourly_wage',
-    sortable: true,
     render: value => (typeof value === 'number' ? parseInt(value, 10) : value)
   },
   {
     title: '一週總工時',
     dataIndex: 'week_work_time',
-    key: 'week_work_time',
-    sortable: true
+    key: 'week_work_time'
   },
   {
     title: '封存狀態',

--- a/src/components/Admin/TimeAndSalary.js
+++ b/src/components/Admin/TimeAndSalary.js
@@ -16,7 +16,7 @@ import withSearchOptionFromRoute from '../../shared/hoc/withSearchOptionFromRout
 import withSortOptionFromRoute from '../../shared/hoc/withSortOptionFromRoute';
 import withHandleTableChange from '../../shared/hoc/withHandleTableChange';
 
-import { ORDER_BY } from '../../shared/constants';
+import { type OrderBy } from '../../shared/constants';
 
 const COLUMNS = [
   {
@@ -29,7 +29,8 @@ const COLUMNS = [
     title: '創建時間',
     dataIndex: 'created_at',
     key: 'created_at',
-    render: createdAt => moment(createdAt).format('LLLL')
+    render: createdAt => moment(createdAt).format('LLLL'),
+    sorter: true
   },
   {
     title: '公司',
@@ -85,10 +86,13 @@ const COLUMNS = [
 type Props = {
   page: number,
   pageSize: number,
-
   searchObj: {
     columnKey: string,
     value: string
+  },
+  sortObj: {
+    sortField: string,
+    orderBy: OrderBy
   },
   setSearchObj: ({
     columnKey: string,
@@ -128,6 +132,7 @@ const withGraphqlData: HOC<*, Props> = compose(
     options: props => {
       const {
         searchObj: { columnKey, value },
+        sortObj: { sortField, orderBy },
         page,
         pageSize
       } = props;
@@ -142,8 +147,8 @@ const withGraphqlData: HOC<*, Props> = compose(
             start: (page - 1) * pageSize,
             limit: pageSize,
             sort: {
-              sort_field: 'CREATED_AT',
-              order_by: ORDER_BY.ASCENDING
+              sort_field: sortField,
+              order_by: orderBy
             }
           }
         }

--- a/src/components/Admin/TimeAndSalary.js
+++ b/src/components/Admin/TimeAndSalary.js
@@ -12,6 +12,7 @@ import AdminLayout from './AdminLayout';
 import FunctionalTable from '../FunctionalTable';
 import withPagination from '../../shared/hoc/withPagination';
 import withSearchOptionFromRoute from '../../shared/hoc/withSearchOptionFromRoute';
+import withSortOptionFromRoute from '../../shared/hoc/withSortOptionFromRoute';
 import { ORDER_BY } from '../../shared/constants';
 
 const COLUMNS = [
@@ -185,6 +186,7 @@ const withGraphqlMutation: HOC<*, Props> = compose(
 );
 
 const hoc = compose(
+  withSortOptionFromRoute,
   withSearchOptionFromRoute,
   withPagination,
   withGraphqlData,

--- a/src/components/Admin/WorkExperience.js
+++ b/src/components/Admin/WorkExperience.js
@@ -4,6 +4,7 @@ import { graphql } from 'react-apollo';
 import { Tag } from 'antd';
 
 import { withProps, compose, type HOC } from 'recompose';
+import moment from 'moment';
 
 import { getWorkExpQL, updateWorkExpQL } from '../../graphql/WorkExperience/';
 import type { ExperienceType } from '../../shared/types/experienceType';
@@ -22,7 +23,12 @@ const COLUMNS = [
     key: 'id',
     searchable: true
   },
-  { title: '創建時間', dataIndex: 'created_at', key: 'created_at' },
+  {
+    title: '創建時間',
+    dataIndex: 'created_at',
+    key: 'created_at',
+    render: createdAt => moment(createdAt).format('LLLL')
+  },
   {
     title: '公司',
     dataIndex: 'company',

--- a/src/components/Admin/WorkExperience.js
+++ b/src/components/Admin/WorkExperience.js
@@ -12,6 +12,7 @@ import AdminLayout from './AdminLayout';
 import FunctionalTable from '../FunctionalTable';
 import withPagination from '../../shared/hoc/withPagination';
 import withSearchOptionFromRoute from '../../shared/hoc/withSearchOptionFromRoute';
+import withSortOptionFromRoute from '../../shared/hoc/withSortOptionFromRoute';
 import { ORDER_BY } from '../../shared/constants';
 
 const COLUMNS = [
@@ -155,6 +156,7 @@ const withGraphqlMutation: HOC<*, Props> = compose(
 );
 
 const hoc = compose(
+  withSortOptionFromRoute,
   withSearchOptionFromRoute,
   withPagination,
   withGraphqlData,

--- a/src/components/Admin/WorkExperience.js
+++ b/src/components/Admin/WorkExperience.js
@@ -14,6 +14,8 @@ import FunctionalTable from '../FunctionalTable';
 import withPagination from '../../shared/hoc/withPagination';
 import withSearchOptionFromRoute from '../../shared/hoc/withSearchOptionFromRoute';
 import withSortOptionFromRoute from '../../shared/hoc/withSortOptionFromRoute';
+import withHandleTableChange from '../../shared/hoc/withHandleTableChange';
+
 import { ORDER_BY } from '../../shared/constants';
 
 const COLUMNS = [
@@ -166,7 +168,8 @@ const hoc = compose(
   withSearchOptionFromRoute,
   withPagination,
   withGraphqlData,
-  withGraphqlMutation
+  withGraphqlMutation,
+  withHandleTableChange
 );
 
 export default hoc(WorkExperience);

--- a/src/components/Admin/WorkExperience.js
+++ b/src/components/Admin/WorkExperience.js
@@ -16,7 +16,7 @@ import withSearchOptionFromRoute from '../../shared/hoc/withSearchOptionFromRout
 import withSortOptionFromRoute from '../../shared/hoc/withSortOptionFromRoute';
 import withHandleTableChange from '../../shared/hoc/withHandleTableChange';
 
-import { ORDER_BY } from '../../shared/constants';
+import { type OrderBy } from '../../shared/constants';
 
 const COLUMNS = [
   {
@@ -29,7 +29,8 @@ const COLUMNS = [
     title: '創建時間',
     dataIndex: 'created_at',
     key: 'created_at',
-    render: createdAt => moment(createdAt).format('LLLL')
+    render: createdAt => moment(createdAt).format('LLLL'),
+    sorter: true
   },
   {
     title: '公司',
@@ -62,10 +63,13 @@ const COLUMNS = [
 type Props = {
   page: number,
   pageSize: number,
-
   searchObj: {
     columnKey: string,
     value: string
+  },
+  sortObj: {
+    sortField: string,
+    orderBy: OrderBy
   },
   setSearchObj: ({
     columnKey: string,
@@ -100,6 +104,7 @@ const withGraphqlData: HOC<*, Props> = compose(
     options: props => {
       const {
         searchObj: { columnKey, value },
+        sortObj: { sortField, orderBy },
         page,
         pageSize
       } = props;
@@ -114,8 +119,8 @@ const withGraphqlData: HOC<*, Props> = compose(
             start: (page - 1) * pageSize,
             limit: pageSize,
             sort: {
-              sort_field: 'CREATED_AT',
-              order_by: ORDER_BY.ASCENDING
+              sort_field: sortField,
+              order_by: orderBy
             }
           }
         }

--- a/src/components/Admin/WorkExperience.js
+++ b/src/components/Admin/WorkExperience.js
@@ -20,6 +20,7 @@ const COLUMNS = [
     key: 'id',
     searchable: true
   },
+  { title: '創建時間', dataIndex: 'created_at', key: 'created_at' },
   {
     title: '公司',
     dataIndex: 'company',

--- a/src/components/Admin/WorkExperience.js
+++ b/src/components/Admin/WorkExperience.js
@@ -12,6 +12,7 @@ import AdminLayout from './AdminLayout';
 import FunctionalTable from '../FunctionalTable';
 import withPagination from '../../shared/hoc/withPagination';
 import withSearchOptionFromRoute from '../../shared/hoc/withSearchOptionFromRoute';
+import { ORDER_BY } from '../../shared/constants';
 
 const COLUMNS = [
   {
@@ -102,7 +103,11 @@ const withGraphqlData: HOC<*, Props> = compose(
               by: columnKey.toUpperCase()
             },
             start: (page - 1) * pageSize,
-            limit: pageSize
+            limit: pageSize,
+            sort: {
+              sort_field: 'CREATED_AT',
+              order_by: ORDER_BY.ASCENDING
+            }
           }
         }
       };

--- a/src/graphql/InterviewExperience/index.js
+++ b/src/graphql/InterviewExperience/index.js
@@ -23,6 +23,7 @@ export const getInterviewExpQL = gql`
           subtitle
           content
         }
+        created_at
       }
     }
   }

--- a/src/graphql/TimeAndSalary/index.js
+++ b/src/graphql/TimeAndSalary/index.js
@@ -21,6 +21,7 @@ export const getTimeSalaryQL = gql`
           is_archived
           reason
         }
+        created_at
       }
     }
   }

--- a/src/graphql/WorkExperience/index.js
+++ b/src/graphql/WorkExperience/index.js
@@ -23,6 +23,7 @@ export const getWorkExpQL = gql`
           subtitle
           content
         }
+        created_at
       }
     }
   }

--- a/src/shared/constants/index.js
+++ b/src/shared/constants/index.js
@@ -22,7 +22,7 @@ export const LOGIN_STATUS: { [key: string]: LoginStatus } = {
   LOGIN_FAIL: 'LOGIN_FAIL'
 };
 
-type OrderBy = 'ASCENDING' | 'DESCENDING';
+export type OrderBy = 'ASCENDING' | 'DESCENDING';
 export const ORDER_BY: { [key: OrderBy]: OrderBy } = {
   ASCENDING: 'ASCENDING',
   DESCENDING: 'DESCENDING'

--- a/src/shared/constants/index.js
+++ b/src/shared/constants/index.js
@@ -21,3 +21,9 @@ export const LOGIN_STATUS: { [key: string]: LoginStatus } = {
   LOGIN_SUCCESS: 'LOGIN_SUCCESS',
   LOGIN_FAIL: 'LOGIN_FAIL'
 };
+
+type OrderBy = 'ASCENDING' | 'DESCENDING';
+export const ORDER_BY: { [key: OrderBy]: OrderBy } = {
+  ASCENDING: 'ASCENDING',
+  DESCENDING: 'DESCENDING'
+};

--- a/src/shared/hoc/withHandleTableChange.js
+++ b/src/shared/hoc/withHandleTableChange.js
@@ -1,8 +1,17 @@
 import { withHandlers, type HOC } from 'recompose';
+import { isEmpty } from 'ramda';
 
 const withHandleTableChange: HOC<*, Props> = withHandlers({
-  handleTableChange: ({ setPage }) => nextPagination => {
+  handleTableChange: ({ setPage, setSortObj }) => (nextPagination, _, nextSorter) => {
     setPage(nextPagination.current);
+
+    if (!isEmpty(nextSorter)) {
+      const { field, order } = nextSorter;
+      setSortObj({
+        sortField: field,
+        orderBy: order
+      });
+    }
   }
 });
 

--- a/src/shared/hoc/withHandleTableChange.js
+++ b/src/shared/hoc/withHandleTableChange.js
@@ -1,0 +1,9 @@
+import { withHandlers, type HOC } from 'recompose';
+
+const withHandleTableChange: HOC<*, Props> = withHandlers({
+  handleTableChange: ({ setPage }) => nextPagination => {
+    setPage(nextPagination.current);
+  }
+});
+
+export default withHandleTableChange;

--- a/src/shared/hoc/withHandleTableChange.js
+++ b/src/shared/hoc/withHandleTableChange.js
@@ -1,5 +1,32 @@
+// @flow
 import { withHandlers, type HOC } from 'recompose';
 import { isEmpty } from 'ramda';
+
+import { type OrderBy } from '../constants';
+import type { ExperienceType } from '../types/experienceType';
+
+type Props = {
+  setPage: number => void,
+  setSortObj: ({
+    sortField: string,
+    orderBy: OrderBy
+  }) => void,
+  page: number,
+  pageSize: number,
+  searchObj: {
+    columnKey: string,
+    value: string
+  },
+  sortObj: {
+    sortField: string,
+    orderBy: OrderBy
+  },
+  setSearchObj: ({
+    columnKey: string,
+    value: string
+  }) => void,
+  expData: Array<ExperienceType>
+};
 
 const withHandleTableChange: HOC<*, Props> = withHandlers({
   handleTableChange: ({ setPage, setSortObj }) => (nextPagination, _, nextSorter) => {

--- a/src/shared/hoc/withPagination.js
+++ b/src/shared/hoc/withPagination.js
@@ -1,5 +1,5 @@
 // @flow
-import { defaultProps, withState, withHandlers, compose, type HOC } from 'recompose';
+import { defaultProps, withState, compose, type HOC } from 'recompose';
 
 type Props = {
   pageSize?: number
@@ -9,12 +9,7 @@ const withPagination: HOC<*, Props> = compose(
   defaultProps({
     pageSize: 10
   }),
-  withState('page', 'setPage', 1),
-  withHandlers({
-    handleTableChange: ({ setPage }) => nextPagination => {
-      setPage(nextPagination.current);
-    }
-  })
+  withState('page', 'setPage', 1)
 );
 
 export default withPagination;

--- a/src/shared/hoc/withSearchOptionFromRoute.js
+++ b/src/shared/hoc/withSearchOptionFromRoute.js
@@ -2,7 +2,6 @@
 import { compose, withHandlers, withProps, type HOC } from 'recompose';
 import { withRouter, type Location, type RouterHistory } from 'react-router-dom';
 
-import * as R from 'ramda';
 import qs from 'qs';
 
 type Props = {
@@ -10,21 +9,10 @@ type Props = {
   history: RouterHistory
 };
 
-const locationToQuery = R.compose(
-  qs.parse,
-  search => {
-    if (search[0] === '?') {
-      return R.tail(search);
-    }
-    return search;
-  },
-  R.prop('search')
-);
-
 const withSearchOptionFromRoute: HOC<*, Props> = compose(
   withRouter,
-  withProps(({ location }) => {
-    let { columnKey, value } = locationToQuery(location);
+  withProps(({ location: { query } }) => {
+    let { columnKey, value } = query;
     if (typeof columnKey === 'undefined' || columnKey === '') {
       columnKey = 'COMPANY';
     }
@@ -34,10 +22,10 @@ const withSearchOptionFromRoute: HOC<*, Props> = compose(
     return { searchObj: { columnKey, value } };
   }),
   withHandlers({
-    submitSearchObj: ({ history, location }) => (columnKey, submitValue) => {
+    submitSearchObj: ({ history, location: { query } }) => (columnKey, submitValue) => {
       history.push({
         search: qs.stringify({
-          ...locationToQuery(location),
+          ...query,
           columnKey,
           value: submitValue
         })

--- a/src/shared/hoc/withSortOptionFromRoute.js
+++ b/src/shared/hoc/withSortOptionFromRoute.js
@@ -1,7 +1,6 @@
 // @flow
 import { compose, withHandlers, withProps, type HOC } from 'recompose';
 import { withRouter, type Location, type RouterHistory } from 'react-router-dom';
-
 import qs from 'qs';
 
 type Props = {
@@ -12,11 +11,35 @@ type Props = {
 const withSortOptionFromRoute: HOC<*, Props> = compose(
   withRouter,
   withProps(({ location: { query: { sortField, orderBy } } }) => ({
-    sortObj: { sortField: sortField || '', orderBy: orderBy || '' }
+    sortObj: { sortField: sortField || 'CREATED_AT', orderBy: orderBy || 'ASCENDING' }
   })),
   withHandlers({
-    submitSortObj: ({ history, location: { query } }) => ({ sortField, orderBy }) => {
-      history.push({ search: qs.stringify({ ...query, sortField, orderBy }) });
+    setSortObj: ({ history, location: { query } }) => ({
+      sortField,
+      orderBy
+    }: {
+      sortField: string,
+      orderBy: string
+    }) => {
+      let nextOrderBy;
+      switch (orderBy) {
+        case 'ascend':
+          nextOrderBy = 'ASCENDING';
+          break;
+        case 'descend':
+          nextOrderBy = 'DESCENDING';
+          break;
+        default:
+          nextOrderBy = '';
+          break;
+      }
+      history.push({
+        search: qs.stringify({
+          ...query,
+          sortField: sortField.toUpperCase(),
+          orderBy: nextOrderBy
+        })
+      });
     }
   })
 );

--- a/src/shared/hoc/withSortOptionFromRoute.js
+++ b/src/shared/hoc/withSortOptionFromRoute.js
@@ -1,0 +1,24 @@
+// @flow
+import { compose, withHandlers, withProps, type HOC } from 'recompose';
+import { withRouter, type Location, type RouterHistory } from 'react-router-dom';
+
+import qs from 'qs';
+
+type Props = {
+  location: Location,
+  history: RouterHistory
+};
+
+const withSortOptionFromRoute: HOC<*, Props> = compose(
+  withRouter,
+  withProps(({ location: { query: { sortField, orderBy } } }) => ({
+    sortObj: { sortField: sortField || '', orderBy: orderBy || '' }
+  })),
+  withHandlers({
+    submitSortObj: ({ history, location: { query } }) => ({ sortField, orderBy }) => {
+      history.push({ search: qs.stringify({ ...query, sortField, orderBy }) });
+    }
+  })
+);
+
+export default withSortOptionFromRoute;

--- a/src/shared/types/experienceType.js
+++ b/src/shared/types/experienceType.js
@@ -9,5 +9,6 @@ export type ExperienceType = {
   title: string,
   regeion: string,
   archive: Archive,
-  salary: Salary
+  salary: Salary,
+  created_type: string
 };

--- a/src/shared/types/workingType.js
+++ b/src/shared/types/workingType.js
@@ -9,5 +9,6 @@ export type Working = {
   salary: Salary,
   weekWorkTime: number,
   estimatedHourlyWage: number,
-  archive: Archive
+  archive: Archive,
+  created_type: string
 };


### PR DESCRIPTION
close: #51 

1. 仿造`withSearchOptionFromRoute` 也寫了一個`withSortOptionFromRoute`
2. 移除`withSearchOptionFromRoute` 中獨立解析query string 的部分（已經有解析過的qs 傳進來了）
3. 忽略後端傳來的graphql error ，主因是一來資料可能會有問題但不影響render ，二來這是admin page 我想應該可以寬容這點。若不做這件事，會明明API 有帶data (with some errors），卻完全沒有render 新得到的資料。